### PR TITLE
export some internals for more flexible programmatic usage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,6 @@ export async function zod2md(options: Options): Promise<string> {
   return formatModelsAsMarkdown(models, options);
 }
 
+export { convertSchemas, formatModelsAsMarkdown, loadZodSchemas }
+
 export type { Config, Options } from './types';


### PR DESCRIPTION
this library is almost perfect for my use case, except that my schemas aren't top-level exports of a single `.ts` file, they're spread across three different files, and i need to select specific schemas from each file for different use cases.

having these functions available to call directly would make it possible to call `convertSchemas` and `formatModelsAsMarkdown` directly with the imported schemas. however, they're not currently available in the bundled module in `dist`.