### PR TITLE
Add support for ZodPipeline and ZodDiscriminatedUnion

### DIFF
--- a/src/converter/convert-schemas.ts
+++ b/src/converter/convert-schemas.ts
@@ -6,6 +6,7 @@ import {
   ZodBranded,
   ZodDate,
   ZodDefault,
+  ZodDiscriminatedUnion,
   ZodEffects,
   ZodEnum,
   ZodFunction,
@@ -18,6 +19,7 @@ import {
   ZodNumber,
   ZodObject,
   ZodOptional,
+  ZodPipeline,
   ZodPromise,
   ZodReadonly,
   ZodRecord,
@@ -239,6 +241,15 @@ function convertSchema(
   }
   if (schema instanceof ZodNever) {
     return convertZodNever(schema);
+  }
+  if (schema instanceof ZodPipeline) {
+    return convertSchema(schema._def.out, exportedSchemas);
+  }
+  if (schema instanceof ZodDiscriminatedUnion) {
+    return {
+      type: 'union',
+      options: schema._def.options.map((option: any) => createModelOrRef(option, exportedSchemas)),
+    };
   }
 
   throw new Error(


### PR DESCRIPTION
We noticed during testing that support for ZodPipeline and ZodDiscriminatedUnion was missing, something that will break if you use something like:
```typescript
export const PostalCodeSchema = z
  .string()
  .transform((postalCode: string) => postalCode.toUpperCase().replaceAll(' ', ''))
  .pipe(z.string().regex(/^\d{4}(?:[A-Z]{2}|\d)?$/, 'Invalid postal code'))
```

Or:
```typescript
export const SomeDiscriminatedUnion = z
  .discriminatedUnion('type', [
    SchemaAWithType,
    SchemaBWithType,
    SchemaCWithType,
  ])
```

As a `DiscriminatedUnion` is basically a union for the purpose of this lib I opted for the same response.
for the `ZodPipeline` case, I opted for the output type.