### PR TITLE
Exported additional model types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,4 +11,13 @@ export async function zod2md(options: Options): Promise<string> {
 
 export { convertSchemas, formatModelsAsMarkdown, loadZodSchemas };
 
-export type { Config, Options } from './types';
+export type {
+  Config,
+  Options,
+  NamedModel,
+  ObjectModel,
+  ModelOrRef,
+  Model,
+  Ref,
+  ModelMeta,
+} from './types';


### PR DESCRIPTION
I'm using `zod2md` programatically (as outlined in #13) and making my own `formatModelsAsMarkdown`.

These types were very useful in making my code a lot less verbose