### PR TITLE
Fix loss of context when using refinements on string schemas

### DIFF
--- a/src/formatter/models/string.spec.ts
+++ b/src/formatter/models/string.spec.ts
@@ -36,6 +36,18 @@ describe('StringModel', () => {
         '_String that is a date and time in ISO 8601 format (any timezone offset)._',
       );
     });
+
+    it('should ignore refinements', () => {
+      expect(
+        new StringModel().renderBlock(
+          z
+            .string()
+            .refine(() => true)
+            .check(() => {})
+            .superRefine(() => {}),
+        ),
+      ).toEqualMarkdown('_String._');
+    });
   });
 
   describe('renderInline', () => {
@@ -61,6 +73,18 @@ describe('StringModel', () => {
       expect(new StringModel().renderInline(z.string().trim())).toEqualMarkdown(
         '`string`',
       );
+    });
+
+    it('should ignore refinements', () => {
+      expect(
+        new StringModel().renderBlock(
+          z
+            .string()
+            .refine(() => true)
+            .check(() => {})
+            .superRefine(() => {}),
+        ),
+      ).toEqualMarkdown('_String._');
     });
   });
 });

--- a/src/formatter/models/string.ts
+++ b/src/formatter/models/string.ts
@@ -169,7 +169,8 @@ export class StringModel implements IModel<StringType> {
 
     return [
       this.#parseStringSubTypeV4(schema),
-      ...(schema._zod.def.checks?.map(this.#parseStringCheckV4) ?? []),
+      ...(schema._zod.def.checks?.map(this.#parseStringCheckV4.bind(this)) ??
+        []),
     ].filter(value => value != null);
   }
 


### PR DESCRIPTION
When listing validations of string schemas, it's possible to fall through the switch statements and into the subtype parser. 

However, when this happens (as far as I know, this mostly concerns refinements), `this` isn't properly captured and will be undefined, causing an exception when the check parse function tries to pass the check on to the subtype parser.